### PR TITLE
Popravljene nedelujoče povezave na prosojnice

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,13 @@ V tem repozitoriju se zbirajo gradiva za predmet Programiranje 1 v 2. letniku ma
 
 Ker vam GitHub ob kliku na HTML datoteko namesto strani prikaže izvorno HTML kodo, je treba prosojnice pogledati s pomočjo strani <http://htmlpreview.github.io>. Tu so direktne povezave na prosojnice:
 
-- [Uvod v OCaml](http://htmlpreview.github.io/?https://github.com/matijapretnar/programiranje-1/blob/master/05-uvod-v-ocaml/predavanja/prosojnice.html)
-- [Funkcije](http://htmlpreview.github.io/?https://github.com/matijapretnar/programiranje-1/blob/master/06-funkcije/predavanja/prosojnice.html)
-- [Definicije tipov](http://htmlpreview.github.io/?https://github.com/matijapretnar/programiranje-1/blob/master/07-definicije-tipov/predavanja/prosojnice.html)
-- [Učinki in čistost](http://htmlpreview.github.io/?https://github.com/matijapretnar/programiranje-1/blob/master/08-ucinki-in-cistost/predavanja/prosojnice.html)
-- [Iskalna drevesa](http://htmlpreview.github.io/?https://github.com/matijapretnar/programiranje-1/blob/master/09-iskalna-drevesa/predavanja/prosojnice.html)
-- [Spremenljive podatkovne strukture](http://htmlpreview.github.io/?https://github.com/matijapretnar/programiranje-1/blob/master/10-spremenljive-podatkovne-strukture/predavanja/prosojnice.html)
+- [Računalniška arhitektura](http://htmlpreview.github.io/?https://github.com/matijapretnar/programiranje-1/blob/master/01-racunalniska-arhitektura/predavanja/prosojnice.html)
+- [Uvod v OCaml](http://htmlpreview.github.io/?https://github.com/matijapretnar/programiranje-1/blob/master/02-uvod-v-ocaml/predavanja/prosojnice.html)
+- [Funkcije](http://htmlpreview.github.io/?https://github.com/matijapretnar/programiranje-1/blob/master/03-funkcije/predavanja/prosojnice.html)
+- [Definicije tipov](http://htmlpreview.github.io/?https://github.com/matijapretnar/programiranje-1/blob/master/04-definicije-tipov/predavanja/prosojnice.html)
+- [Modularnost](http://htmlpreview.github.io/?https://github.com/matijapretnar/programiranje-1/blob/master/07-modularnost/predavanja/prosojnice.html)
+- [Spremenljive podatkovne strukture](http://htmlpreview.github.io/?https://github.com/matijapretnar/programiranje-1/blob/master/09-spremenljive-podatkovne-strukture/predavanja/prosojnice.html)
+- [Urejanje](http://htmlpreview.github.io/?https://github.com/matijapretnar/programiranje-1/blob/master/10-urejanje/predavanja/prosojnice.html)
 - [Deli in vladaj](http://htmlpreview.github.io/?https://github.com/matijapretnar/programiranje-1/blob/master/11-deli-in-vladaj/predavanja/prosojnice.html)
 - [Dinamično programiranje](http://htmlpreview.github.io/?https://github.com/matijapretnar/programiranje-1/blob/master/12-dinamicno-programiranje/predavanja/prosojnice.html)
 - [Memoizacija v Pythonu](http://htmlpreview.github.io/?https://github.com/matijapretnar/programiranje-1/blob/master/13-memoizacija-v-pythonu/predavanja/prosojnice.html)


### PR DESCRIPTION
Več povezav ni delovalo zaradi spremembe vrstnega reda predavanj in pri nekaterih poglavjih sploh ni več prosojnic