### PR TITLE
Manjši popravek pri definiciji funkcije step

### DIFF
--- a/zapiski/09-izracunljivost.md
+++ b/zapiski/09-izracunljivost.md
@@ -43,9 +43,9 @@ Delna funkcija $\mathsf{step}_M : \mathbb{K}_M \rightharpoonup \mathbb{K}_M$, ki
 
 $$
 \mathsf{step}_M(q, t, i) = \begin{cases}
-  (q', t[i \mapsto a], i - 1) & \delta(q, t(i)) = (q', a, \mathtt{L}) \\
-  (q', t[i \mapsto a], i + 1) & \delta(q, t(i)) = (q', a, \mathtt{R}) \\
-  \uparrow & \delta(q, t(i)) \uparrow
+  (q', t[i \mapsto a], i - 1) & \delta(t(i), q) = (a, q', \mathtt{L}) \\
+  (q', t[i \mapsto a], i + 1) & \delta(t(i), q) = (a, q', \mathtt{R}) \\
+  \uparrow & \delta(t(i), q) \uparrow
 \end{cases}
 $$
 


### PR DESCRIPTION
V definiciji Turingovega stroja je prehodna funkcija definirana kot $\delta: \Gamma \times Q \to \Gamma \times Q \times \{L, R\}$, pri funkciji step, pa se zaporedje parametrov narobe uporablja, tj., smatra funkcijo $\delta$ kot da slika iz $Q \times \Gamma$. Spremenil sem funkcijo step, sicer bi pa verjetno lahko tudi definicijo $\delta$, nisem prepričan kaj bi bilo bolj prikladno.